### PR TITLE
chore: use  peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,47 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TARGET_BRANCH: gh-pages
-      PUBLIC_DIR: .book
+      PUBLISH_BRANCH: gh-pages # for peaceiris/actions-gh-pages
+      PUBLISH_DIR: .book # for peaceiris/actions-gh-pages
       MDBOOK_VERSION: v0.3.5
 
     steps:
       - uses: actions/checkout@v1
 
-      - name: Cache rustup
-        uses: actions/cache@v1
-        with:
-          path: ~/.rustup
-          key: ${{ runner.os }}-rustup
-
-      - name: Cache cargo binaries
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
-          restore-key: |
-            ${{ runner.os }}-cargo-bin-
-
-      - name: Install stable Rust
-        run: |
-          rustup set profile default
-          rustup update stable
-          rustup default stable
-
       - name: Download mdBook
-        run: >
-          curl -L 
-          "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          | tar zxv
-
-      - name: Setup worktree
         run: |
-          rm -rf "${PUBLIC_DIR}"
-          mkdir "${PUBLIC_DIR}"
-          git worktree prune
-          rm -rf ".git/worktrees/${PUBLIC_DIR}/"
-          git worktree add -B "${TARGET_BRANCH}" "${PUBLIC_DIR}" "origin/${TARGET_BRANCH}"
-          rm -rf "${PUBLIC_DIR}/*"
+          export TARBALL="mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          export REPO="https://github.com/rust-lang/mdBook"
+          curl -L "${REPO}/releases/download/${MDBOOK_VERSION}/${TARBALL}" | tar zxv
 
       - name: Build the book
         run: |
@@ -60,14 +31,10 @@ jobs:
           ./mdbook build -d __tmp_book
           cargo doc --lib --no-deps
           mv "target/doc" __tmp_book/
-          cp -rp __tmp_book/* "${PUBLIC_DIR}/"
+          cp -rp __tmp_book/* "${PUBLISH_DIR}/"
           rm -rf __tmp_book
 
-      - name: Deploy to GitHug Page
-        run: |
-          cd "${PUBLIC_DIR}"
-          git config --global user.email "weihanglo@users.noreply.github.com"
-          git config --global user.name "GitHub Actions"
-          git add --all -v
-          git commit -v -m "Published on ${GITHUB_SHA:0:7} at $(date)" | tee
-          git push -v -f https://${GITHUB_ACTOR}:${{ secrets.ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git ${TARGET_BRANCH}
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v2.5.0
+        env:
+          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
# What

- Use [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) to deploy static pages to GitHub Page
- Instead of personal access to token, transit to deploy key for deployment.