### PR TITLE
Refactor: stack implementation cleanup

### DIFF
--- a/src/collections/stack/mod.rs
+++ b/src/collections/stack/mod.rs
@@ -90,41 +90,43 @@ impl<T> Stack<T> {
 
 #[cfg(test)]
 mod impl_by_vec {
+    use super::*;
+
     #[test]
-        let stack = super::Stack::<u32>::with_capacity(10);
     fn new_with_capacity() {
+        let stack: Stack<u32> = Stack::with_capacity(10);
         assert_eq!(10, stack.items.capacity());
     }
 
     #[test]
-        let mut stack = super::Stack::<u32>::with_capacity(1);
-        stack.push(1u32);
-        assert_eq!(Some(1u32), stack.pop());
     fn pop() {
+        let mut stack = Stack::with_capacity(1);
+        stack.push(1);
+        assert_eq!(Some(1), stack.pop());
         assert_eq!(None, stack.pop());
     }
 
     #[test]
-        let mut stack = super::Stack::<u32>::with_capacity(1);
-        stack.push(32u32);
-        assert_eq!(Some(&32u32), stack.peek());
     fn push() {
+        let mut stack = Stack::with_capacity(1);
+        stack.push(32);
+        assert_eq!(Some(&32), stack.peek());
         assert_eq!(1, stack.size());
     }
 
     #[test]
-        let mut stack = super::Stack::<u32>::with_capacity(1);
-        assert_eq!(true, stack.push(1u32));
-        assert_eq!(Some(&1u32), stack.peek());
-        assert_eq!(false, stack.push(2u32));
     fn push_maxsize() {
+        let mut stack = Stack::with_capacity(1);
+        assert_eq!(true, stack.push(1));
+        assert_eq!(Some(&1), stack.peek());
+        assert_eq!(false, stack.push(2));
     }
 
     #[test]
-        let mut stack = super::Stack::<u32>::with_capacity(1);
     fn size() {
+        let mut stack = Stack::with_capacity(1);
         assert_eq!(0, stack.size());
-        stack.push(1u32);
+        stack.push(1);
         assert_eq!(1, stack.size());
     }
 }

--- a/src/collections/stack/mod.rs
+++ b/src/collections/stack/mod.rs
@@ -89,40 +89,40 @@ impl<T> Stack<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod impl_by_vec {
     #[test]
-    fn test_new_with_capacity() {
         let stack = super::Stack::<u32>::with_capacity(10);
+    fn new_with_capacity() {
         assert_eq!(10, stack.items.capacity());
     }
 
     #[test]
-    fn test_pop() {
         let mut stack = super::Stack::<u32>::with_capacity(1);
         stack.push(1u32);
         assert_eq!(Some(1u32), stack.pop());
+    fn pop() {
         assert_eq!(None, stack.pop());
     }
 
     #[test]
-    fn test_push() {
         let mut stack = super::Stack::<u32>::with_capacity(1);
         stack.push(32u32);
         assert_eq!(Some(&32u32), stack.peek());
+    fn push() {
         assert_eq!(1, stack.size());
     }
 
     #[test]
-    fn test_push_maxsize() {
         let mut stack = super::Stack::<u32>::with_capacity(1);
         assert_eq!(true, stack.push(1u32));
         assert_eq!(Some(&1u32), stack.peek());
         assert_eq!(false, stack.push(2u32));
+    fn push_maxsize() {
     }
 
     #[test]
-    fn test_size() {
         let mut stack = super::Stack::<u32>::with_capacity(1);
+    fn size() {
         assert_eq!(0, stack.size());
         stack.push(1u32);
         assert_eq!(1, stack.size());


### PR DESCRIPTION
- Simplify test cases' name
- Remove unnecessary type argument.