### PR TITLE
collection/singly_linked_list: 更改了一处写法。

### DIFF
--- a/src/collections/singly_linked_list/README.md
+++ b/src/collections/singly_linked_list/README.md
@@ -401,11 +401,27 @@ impl<T> SinglyLinkedList<T> {
 
 最後，`IterMut` 與 `Iter` 迭代器實作上大同小異。把 `Iter` 用到 `Option.as_ref()` 改為 `Option.as_mut()`，其他 `&` 改成 `&mut` 即可。
 
-> Rust 1.14.0为Option新增了`as_deref()`和`as_deref_mut()`两种新的方法。可以直接将`Option<T>`或`&Option<T>`转换为`Option<&T>`类型，第4条的内容可以。因此，新的实现如下
+> Rust 1.14.0为Option新增了`as_deref()`和`as_deref_mut()`两种新的方法。可以直接将`Option<T>`或`&Option<T>`转换为`Option<&T>`类型，可以不再用3、4两条的方法了。因此，新的实现如下
 > ```Rust
-//        Iter { next: self.head.as_ref().map(|node| &**node) } // old
-          Iter { next: self.head.as_deref() } //new
-```
+> impl<T> Iterator for Iter<'a, T> {
+>    type Item = &'a T;                          // 2
+>    fn next(&mut self) -> Option<Self::Item> {
+>        match self.next {
+>            Some(node) => {
+>                // self.next = node.next.as_ref().map(|node| &**node); // old
+>                self.next = node.next.as_deref();  //new
+>                Some(&node.elem)
+>            }
+>            None => None,
+>        }
+>     }
+> }
+> // ....
+>       pub fn iter(&self) -> Iter<T> {
+> //        Iter { next: self.head.as_ref().map(|node| &**node) } // old
+>           Iter { next: self.head.as_deref() } //new
+>       }
+> ```
 > 参考: [Rust文档](https://doc.rust-lang.org/std/option/enum.Option.html#method.as_deref)
 
 ### PartialEq trait

--- a/src/collections/singly_linked_list/README.md
+++ b/src/collections/singly_linked_list/README.md
@@ -401,6 +401,13 @@ impl<T> SinglyLinkedList<T> {
 
 最後，`IterMut` 與 `Iter` 迭代器實作上大同小異。把 `Iter` 用到 `Option.as_ref()` 改為 `Option.as_mut()`，其他 `&` 改成 `&mut` 即可。
 
+> Rust 1.14.0为Option新增了`as_deref()`和`as_deref_mut()`两种新的方法。可以直接将`Option<T>`或`&Option<T>`转换为`Option<&T>`类型，第4条的内容可以。因此，新的实现如下
+> ```Rust
+//        Iter { next: self.head.as_ref().map(|node| &**node) } // old
+          Iter { next: self.head.as_deref() } //new
+```
+> 参考: [Rust文档](https://doc.rust-lang.org/std/option/enum.Option.html#method.as_deref)
+
 ### PartialEq trait
 
 [PartialEq trait](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html) 是用來實現兩個串列是否能夠比較，而我們在此定義如下：

--- a/src/collections/singly_linked_list/mod.rs
+++ b/src/collections/singly_linked_list/mod.rs
@@ -213,7 +213,7 @@ impl<T> SinglyLinkedList<T> {
     /// Creates an iterator that yields mutable reference of each element.
     pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut {
-            next: self.head.as_deref_mut()
+            next: self.head.as_deref_mut(),
         }
     }
 }

--- a/src/collections/singly_linked_list/mod.rs
+++ b/src/collections/singly_linked_list/mod.rs
@@ -206,14 +206,14 @@ impl<T> SinglyLinkedList<T> {
     /// Creates an iterator that yields immutable reference of each element.
     pub fn iter(&self) -> Iter<T> {
         Iter {
-            next: self.head.as_ref().map(|node| &**node),
+            next: self.head.as_deref(),
         }
     }
 
     /// Creates an iterator that yields mutable reference of each element.
     pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut {
-            next: self.head.as_mut().map(|node| &mut **node),
+            next: self.head.as_deref_mut()
         }
     }
 }
@@ -232,7 +232,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.next {
             Some(node) => {
-                self.next = node.next.as_ref().map(|node| &**node);
+                self.next = node.next.as_deref();
                 Some(&node.elem)
             }
             None => None,
@@ -245,7 +245,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.next.take() {
             Some(node) => {
-                self.next = node.next.as_mut().map(|node| &mut **node);
+                self.next = node.next.as_deref_mut();
                 Some(&mut node.elem)
             }
             None => None,


### PR DESCRIPTION
由于`as_ref().map(|node| &**node)`的写法比较迷惑，替换成了1.14.0新增的`as_deref()`写法。