### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/collections/deque/mod.rs
+++ b/src/collections/deque/mod.rs
@@ -242,9 +242,9 @@ impl<T> Deque<T> {
                 // The content of ring buffer won't overlapped, so it's safe to
                 // call `copy_nonoverlapping`. It's also safe to advance the
                 // pointer by `old_cap` since the buffer has been doubled.
+                let src = self.ptr(); // 4-1
+                let dst = unsafe { self.ptr().add(old_cap) }; // 4-2
                 unsafe {
-                    let src = self.ptr(); // 4-1
-                    let dst = self.ptr().add(old_cap); // 4-2
                     ptr::copy_nonoverlapping(src, dst, self.head);
                 }
                 self.head += old_cap; // 5
@@ -354,11 +354,11 @@ impl<'a, T> Iterator for IterMut<'a, T> {
         // trait: the `&mut self` is bound to an anonymous lifetime which rustc
         // cannot figure out whether it would outlive returning element. Hence
         // the explicit pointer casting is required.
-        unsafe {
+        
             let ptr = self.ring_buf as *mut [T]; // 1
-            let slice = &mut *ptr; // 2
+            let slice = unsafe { &mut *ptr }; // 2
             slice.get_mut(tail) // 3
-        }
+        
     }
 }
 // ANCHOR_END: IterMut


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html